### PR TITLE
change --background-darker to stay consistent with the default theme

### DIFF
--- a/themes/catppuccin-frappe.css
+++ b/themes/catppuccin-frappe.css
@@ -4,9 +4,9 @@ body.catppuccin-frappe {
   --navbar-accent: #c6d0f5;
   --background: #303446;
   --body-background: var(--background);
-  --background-darker: #232634;
+  --background-darker: var(--background);
   --current-background: var(--body-background);
-  --navbar-background: #292c3c;
+  --navbar-background: #232634;
   --navbar-active-background: #626880;
   --gradient-body-background: linear-gradient(
     90deg,

--- a/themes/catppuccin-latte.css
+++ b/themes/catppuccin-latte.css
@@ -4,9 +4,9 @@ body.catppuccin-latte {
   --navbar-accent: #4c4f69;
   --background: #eff1f5;
   --body-background: var(--background);
-  --background-darker: #dce0e8;
+  --background-darker: var(--background);
   --current-background: var(--body-background);
-  --navbar-background: #e6e9ef;
+  --navbar-background: #dce0e8;
   --navbar-active-background: #acb0be;
   --gradient-body-background: linear-gradient(
     90deg,

--- a/themes/catppuccin-macchiato.css
+++ b/themes/catppuccin-macchiato.css
@@ -4,9 +4,9 @@ body.catppuccin-macchiato {
   --navbar-accent: #cad3f5;
   --background: #24273a;
   --body-background: var(--background);
-  --background-darker: #181926;
+  --background-darker: var(--background);
   --current-background: var(--body-background);
-  --navbar-background: #1e2030;
+  --navbar-background: #181926;
   --navbar-active-background: #5b6078;
   --gradient-body-background: linear-gradient(
     90deg,

--- a/themes/catppuccin-mocha.css
+++ b/themes/catppuccin-mocha.css
@@ -4,9 +4,9 @@ body.catppuccin-mocha {
   --navbar-accent: #cdd6f4;
   --background: #1e1e2e;
   --body-background: var(--background);
-  --background-darker: #11111b;
+  --background-darker: var(--background);
   --current-background: var(--body-background);
-  --navbar-background: #181825;
+  --navbar-background: #11111b;
   --navbar-active-background: #585b70;
   --gradient-body-background: linear-gradient(
     90deg,


### PR DESCRIPTION
I suspect something changed upstream with heroic, and --background-darker now effects the "Recently Played" and "All Games" headers, which are, in the default heroic theme and in the screenshots in this repo, the same color as --background.

Note - Apologies if I did something wrong with this, I'm *very* new to pull requests and contributing to projects in general.